### PR TITLE
Fix individual post purchase

### DIFF
--- a/laterpay/application/Controller/Admin/Pricing.php
+++ b/laterpay/application/Controller/Admin/Pricing.php
@@ -799,7 +799,7 @@ class LaterPay_Controller_Admin_Pricing extends LaterPay_Controller_Admin_Base
             $only_time_pass = 0; // allow individual and time pass purchases
         }
 
-        if ( $only_time_pass === 1 && ! LaterPay_Helper_TimePass::get_time_passes_count() ) {
+        if ( 1 === $only_time_pass && ! LaterPay_Helper_TimePass::get_time_passes_count( true ) ) {
             $event->set_result(
                 array(
                     'success' => false,

--- a/laterpay/application/Helper/TimePass.php
+++ b/laterpay/application/Helper/TimePass.php
@@ -542,11 +542,13 @@ class LaterPay_Helper_TimePass
     /*
      * Get count of existing time passes.
      *
+     * @param bool $ignore_deleted ignore count of deleted pass.
+     *
      * @return int count of time passes
      */
-    public static function get_time_passes_count() {
+    public static function get_time_passes_count( $ignore_deleted = false ) {
         $model = LaterPay_Model_TimePassWP::get_instance();
 
-        return $model->get_time_passes_count();
+        return $model->get_time_passes_count( $ignore_deleted );
     }
 }


### PR DESCRIPTION
**A user has to create a time-pass, before disabling individual post purchases.**

This fixes the issue which allowed disabling individual purchase even without creating a time-pass